### PR TITLE
indentation fixed of arq_in in harmonix_extrapolation

### DIFF
--- a/harmonic_extrapolation.py
+++ b/harmonic_extrapolation.py
@@ -73,7 +73,7 @@ def read_input(input_file):
                 elif linha[0] == "limit_disp_neg_freq":
                     limit_disp_neg_freq = float(linha[1])
 
-    arq_in.close()
+        arq_in.close()
 
 
 


### PR DESCRIPTION
`arq_in` was one indentation level too low. Fixed by moving it into the `if` statement.